### PR TITLE
Fix(fpm.toml): explicitly enforce implicit-external interfaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         sudo ldconfig
 
     - name: Install fpm
-      uses: fortran-lang/setup-fpm@v3
+      uses: fortran-lang/setup-fpm@v5
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         sudo ldconfig
 
     - name: Install fpm
-      uses: fortran-lang/setup-fpm@v3
+      uses: fortran-lang/setup-fpm@v5
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -5,3 +5,6 @@ copyright = "University Corporation for Atmospheric Research/Unidata"
 
 [build]
 link = ["netcdff","netcdf"]
+
+[fortran]
+implicit-external = true


### PR DESCRIPTION
`fpm` 0.8.1 passes `Werror=implicit-interface` by default so the use of implicit interfaces must be explicitly enabled in the manifest